### PR TITLE
ecocounter: add ResolutionFifteenMinute

### DIFF
--- a/cmd/ecocounter-fetch/main.go
+++ b/cmd/ecocounter-fetch/main.go
@@ -33,6 +33,8 @@ func main() {
 		cres = ecocounter.ResolutionDay
 	case "hour":
 		cres = ecocounter.ResolutionHour
+	case "15m":
+		cres = ecocounter.ResolutionFifteenMinute
 	default:
 		log.Fatalf("unknown resolution %q, try day or hour", *res)
 	}

--- a/ecocounter/client.go
+++ b/ecocounter/client.go
@@ -12,12 +12,13 @@ import (
 )
 
 // A Resolution is used when retrieving data using GetDatapoints.
-// Currently only day and hour are supported.
 type Resolution int
 
 const (
+	// ResolutionFifteenMinute requests data at 15 minute resolution.
+	ResolutionFifteenMinute Resolution = 2
 	// ResolutionHour requests hourly data.
-	ResolutionHour Resolution = 2
+	ResolutionHour Resolution = 3
 	// ResolutionDay requests daily data.
 	ResolutionDay Resolution = 4
 )

--- a/ecocounter/client_test.go
+++ b/ecocounter/client_test.go
@@ -30,7 +30,7 @@ func TestGetDatapoints(t *testing.T) {
 		wantValues := url.Values{
 			"begin": []string{begin.Format(requestDateFormat)},
 			"end":   []string{end.Format(requestDateFormat)},
-			"step":  []string{"2"},
+			"step":  []string{"3"},
 		}
 		if got := r.URL.Query(); !reflect.DeepEqual(got, wantValues) {
 			t.Errorf("got query values\n%+v\nwant\n%+v", got, wantValues)


### PR DESCRIPTION
It was previously thought that resolution value 2 was hourly. Instead,
2 is every 15 minutes and 3 is hourly.