### PR TITLE
cmd/bikehfx-tweet: support non-public counters

### DIFF
--- a/cmd/bikehfx-tweet/graph.go
+++ b/cmd/bikehfx-tweet/graph.go
@@ -15,14 +15,14 @@ func makeHourlyGraph(cl *ecocounter.Client, day time.Time) ([]byte, error) {
 		max    int
 	)
 
-	for i, c := range counters {
+	for i, c := range publicCounters {
 		ds, err := cl.GetDatapoints(c.ecoID, day, day, ecocounter.ResolutionHour)
 		if err != nil {
 			return nil, err
 		}
 
 		ts := chart.TimeSeries{
-			Name: c.name,
+			Name: c.name(),
 			Style: chart.Style{
 				StrokeDashArray: strokeDashArray(i),
 			},


### PR DESCRIPTION
Uses ecocounter/Client.GetNonPublicDatapoints to fetch daily data for the South Park St counter which doesn't have the Public Web Page option enabled.